### PR TITLE
Additional acceptance tests and validation for output sources

### DIFF
--- a/azurerm/resource_arm_streamanalytics_job.go
+++ b/azurerm/resource_arm_streamanalytics_job.go
@@ -803,7 +803,6 @@ func resourceArmStreamAnalyticsParseOutput(data map[string]interface{}) (*stream
 }
 
 func parseArmStreamAnalyticsOutputDatasource(data map[string]interface{}) (streamanalytics.BasicOutputDataSource, error) {
-	name := data["name"].(string)
 	datasource := data["datasource"].(string)
 
 	switch datasource {
@@ -835,104 +834,104 @@ func parseArmStreamAnalyticsOutputDatasource(data map[string]interface{}) (strea
 		return &result, nil
 
 	case string(streamanalytics.TypeMicrosoftServiceBusEventHub):
-		if data["service_bus_namespace"] == nil {
-			return nil, fmt.Errorf("Event Hub output %s missing required field service_bus_namespace", name)
+		namespace, err := extractAndValidateRequiredProperty(data, "service_bus_namespace")
+		if err != nil {
+			return nil, err
 		}
-		namespace := data["service_bus_namespace"].(string)
-
-		if data["eventhub_name"] == nil {
-			return nil, fmt.Errorf("Event Hub output %s missing required field eventhub_name", name)
+		eventHub, err := extractAndValidateRequiredProperty(data, "eventhub_name")
+		if err != nil {
+			return nil, err
 		}
-		eventhub := data["eventhub_name"].(string)
-
-		if data["shared_access_policy_name"] == nil {
-			return nil, fmt.Errorf("Event Hub output %s missing required field shared_access_policy_name", name)
+		policyName, err := extractAndValidateRequiredProperty(data, "shared_access_policy_name")
+		if err != nil {
+			return nil, err
 		}
-		policyName := data["shared_access_policy_name"].(string)
-
-		if data["shared_access_policy_key"] == nil {
-			return nil, fmt.Errorf("Event Hub output %s missing required field shared_access_policy_key", name)
+		policyKey, err := extractAndValidateRequiredProperty(data, "shared_access_policy_key")
+		if err != nil {
+			return nil, err
 		}
-		policyKey := data["shared_access_policy_key"].(string)
+		partitionKey := extractOptionalProperty(data, "eventhub_partition_key")
 
 		result := streamanalytics.EventHubOutputDataSource{
 			Type: streamanalytics.TypeMicrosoftServiceBusEventHub,
 			EventHubOutputDataSourceProperties: &streamanalytics.EventHubOutputDataSourceProperties{
-				ServiceBusNamespace:    &namespace,
-				SharedAccessPolicyName: &policyName,
-				SharedAccessPolicyKey:  &policyKey,
-				EventHubName:           &eventhub,
+				ServiceBusNamespace:    namespace,
+				SharedAccessPolicyName: policyName,
+				SharedAccessPolicyKey:  policyKey,
+				EventHubName:           eventHub,
+				PartitionKey:		partitionKey,
 			},
-		}
-
-		if v := data["eventhub_partition_key"]; v != nil {
-			value := v.(string)
-			result.EventHubOutputDataSourceProperties.PartitionKey = &value
 		}
 
 		return &result, nil
 
 	case string(streamanalytics.TypeMicrosoftSQLServerDatabase):
-		// TODO Validate fields
-		databaseServer := data["database_server"].(string)
-		databaseName := data["database_name"].(string)
-		databaseTable := data["database_table"].(string)
-		databaseUser := data["database_user"].(string)
-		databasePassword := data["database_password"].(string)
+		databaseServer, err := extractAndValidateRequiredProperty(data, "database_server")
+		if err != nil {
+			return nil, err
+		}
+		databaseName, err := extractAndValidateRequiredProperty(data, "database_name")
+		if err != nil {
+			return nil, err
+		}
+		databaseTable, err := extractAndValidateRequiredProperty(data, "database_table")
+		if err != nil {
+			return nil, err
+		}
+		databaseUser, err := extractAndValidateRequiredProperty(data, "database_user")
+		if err != nil {
+			return nil, err
+		}
+		databasePassword, err := extractAndValidateRequiredProperty(data, "database_password")
+		if err != nil {
+			return nil, err
+		}
 
 		result := streamanalytics.AzureSQLDatabaseOutputDataSource{
 			Type: streamanalytics.TypeMicrosoftSQLServerDatabase,
 			AzureSQLDatabaseOutputDataSourceProperties: &streamanalytics.AzureSQLDatabaseOutputDataSourceProperties{
-				Server:   &databaseServer,
-				Database: &databaseName,
-				User:     &databaseUser,
-				Password: &databasePassword,
-				Table:    &databaseTable,
+				Server:   databaseServer,
+				Database: databaseName,
+				User:     databaseUser,
+				Password: databasePassword,
+				Table:    databaseTable,
 			},
 		}
 
 		return &result, nil
 
 	case string(streamanalytics.TypeMicrosoftStorageBlob):
-		// TODO Verify validation
-		if data["storage_account_name"] == nil {
-			return nil, fmt.Errorf("Output %s missing storage_account_name field", name)
+		accountName, err := extractAndValidateRequiredProperty(data, "storage_account_name")
+		if err != nil {
+			return nil, err
 		}
-		if data["storage_account_key"] == nil {
-			return nil, fmt.Errorf("Output %s missing storage_account_key field", name)
+		accountKey, err := extractAndValidateRequiredProperty(data, "storage_account_key")
+		if err != nil {
+			return nil, err
 		}
-		if data["storage_container"] == nil {
-			return nil, fmt.Errorf("Output %s missing storage_container field", name)
+		container, err := extractAndValidateRequiredProperty(data, "storage_container")
+		if err != nil {
+			return nil, err
 		}
-		if data["storage_path_pattern"] == nil {
-			return nil, fmt.Errorf("Output %s missing storage_path_pattern field", name)
+		pathPattern, err := extractAndValidateRequiredProperty(data, "storage_path_pattern")
+		if err != nil {
+			return nil, err
 		}
-		if data["storage_date_format"] == nil {
-			return nil, fmt.Errorf("Output %s missing storage_date_format field", name)
-		}
-		if data["storage_time_format"] == nil {
-			return nil, fmt.Errorf("Output %s missing storage_time_format field", name)
-		}
-
-		accountName := data["storage_account_name"].(string)
-		accountKey := data["storage_account_key"].(string)
-		container := data["storage_container"].(string)
-		pathPattern := data["storage_path_pattern"].(string)
-		dateFormat := data["storage_date_format"].(string)
-		timeFormat := data["storage_time_format"].(string)
+		dateFormat := extractOptionalProperty(data, "storage_date_format")
+		timeFormat := extractOptionalProperty(data, "storage_time_format")
 
 		accounts := make([]streamanalytics.StorageAccount, 1)
-		accounts[0].AccountName = &accountName
-		accounts[0].AccountKey = &accountKey
+		accounts[0].AccountName = accountName
+		accounts[0].AccountKey = accountKey
 
 		result := streamanalytics.BlobOutputDataSource{
 			Type: streamanalytics.TypeMicrosoftStorageBlob,
 			BlobOutputDataSourceProperties: &streamanalytics.BlobOutputDataSourceProperties{
 				StorageAccounts: &accounts,
-				Container:       &container,
-				PathPattern:     &pathPattern,
-				DateFormat:      &dateFormat,
-				TimeFormat:      &timeFormat,
+				Container:       container,
+				PathPattern:     pathPattern,
+				DateFormat:      dateFormat,
+				TimeFormat:      timeFormat,
 			},
 		}
 
@@ -941,6 +940,24 @@ func parseArmStreamAnalyticsOutputDatasource(data map[string]interface{}) (strea
 	default:
 		return nil, fmt.Errorf("Unknown output datasource type: %q", datasource)
 	}
+}
+
+func extractAndValidateRequiredProperty(props map[string]interface{}, k string) (*string, error) {
+	value := props[k].(string)
+	if len(value) > 0 {
+		return utils.String(value), nil
+	}
+
+	return nil, fmt.Errorf("Missing value for required property `%s`", k)
+}
+
+func extractOptionalProperty(props map[string]interface{}, k string) *string {
+	value := props[k].(string)
+	if len(value) > 0 {
+		return utils.String(value)
+	}
+
+	return nil
 }
 
 func parseArmStreamAnalyticsReferenceDatasource(data map[string]interface{}) (streamanalytics.BasicReferenceInputDataSource, error) {

--- a/azurerm/resource_arm_streamanalytics_job.go
+++ b/azurerm/resource_arm_streamanalytics_job.go
@@ -152,8 +152,7 @@ func resourceArmStreamAnalyticsJob() *schema.Resource {
 			"input": {
 				Type:        schema.TypeList,
 				Description: "Datasources to be used by queries.",
-				Required:    true,
-				MinItems:    1,
+				Optional:    true,
 				// TODO: When Terraform supports validating lists and sets.
 				// ValidateFunc: validateInput,
 				Elem: &schema.Resource{
@@ -229,6 +228,7 @@ func resourceArmStreamAnalyticsJob() *schema.Resource {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
+
 						// Shared Event and IoT Hub fields
 						"shared_access_policy_name": {
 							Type:     schema.TypeString,
@@ -243,6 +243,7 @@ func resourceArmStreamAnalyticsJob() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+
 						// Event Hub fields
 						"service_bus_namespace": {
 							Type:     schema.TypeString,
@@ -252,6 +253,7 @@ func resourceArmStreamAnalyticsJob() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+
 						// IoT Hub fields
 						"iot_hub_namespace": {
 							Type:     schema.TypeString,
@@ -268,9 +270,8 @@ func resourceArmStreamAnalyticsJob() *schema.Resource {
 			// To avoid having to split the single transformation when we
 			// read.
 			"transformation": {
-				Type:        schema.TypeList,
-				Required:    true,
-				MinItems:    1,
+				Type:     schema.TypeList,
+				Optional: true,
 				MaxItems:    1,
 				Description: "SQL query to execute.",
 				Elem: &schema.Resource{
@@ -294,9 +295,8 @@ func resourceArmStreamAnalyticsJob() *schema.Resource {
 			},
 
 			"output": {
-				Type:        schema.TypeList,
-				Required:    true,
-				MinItems:    1,
+				Type:     schema.TypeList,
+				Optional: true,
 				Description: "Data outputs to be updated by queries.",
 				// TODO: When Terraform supports validating lists and sets.
 				// ValidateFunc: validateOutput,
@@ -1377,10 +1377,6 @@ func validateArmStreamAnalyticsInputDatasource(v interface{}, k string) (ws []st
 	switch value {
 	case string(streamanalytics.TypeBasicReferenceInputDataSourceTypeMicrosoftStorageBlob):
 		return
-	// No need to check this case as it's identical to the above.
-	//
-	// case string(streamanalytics.TypeStreamInputDataSourceTypeMicrosoftStorageBlob):
-	// 	return
 	case string(streamanalytics.TypeBasicStreamInputDataSourceTypeMicrosoftDevicesIotHubs):
 		return
 	case string(streamanalytics.TypeBasicStreamInputDataSourceTypeMicrosoftServiceBusEventHub):
@@ -1402,11 +1398,11 @@ func validateArmStreamAnalyticsOutputDatasource(v interface{}, k string) (ws []s
 		return
 	case string(streamanalytics.TypeMicrosoftSQLServerDatabase):
 		return
+	case string(streamanalytics.TypeMicrosoftStorageBlob):
+		return
 	case string(streamanalytics.TypeMicrosoftServiceBusQueue):
 		errors = append(errors, fmt.Errorf("Output datasource not currently supported: %q", value))
 	case string(streamanalytics.TypeMicrosoftServiceBusTopic):
-		errors = append(errors, fmt.Errorf("Output datasource not currently supported: %q", value))
-	case string(streamanalytics.TypeMicrosoftStorageBlob):
 		errors = append(errors, fmt.Errorf("Output datasource not currently supported: %q", value))
 	case string(streamanalytics.TypeMicrosoftStorageDocumentDB):
 		errors = append(errors, fmt.Errorf("Output datasource not currently supported: %q", value))

--- a/azurerm/resource_arm_streamanalytics_job.go
+++ b/azurerm/resource_arm_streamanalytics_job.go
@@ -945,6 +945,8 @@ func parseArmStreamAnalyticsOutputDatasource(data map[string]interface{}) (strea
 	}
 }
 
+//TODO expand to handle non-string types
+//Include resource that is broken in error message
 func extractAndValidateRequiredProperty(props map[string]interface{}) func(string) (*string, error) {
 	return func(k string) (*string, error) {
 		value := props[k].(string)

--- a/azurerm/resource_arm_streamanalytics_job_test.go
+++ b/azurerm/resource_arm_streamanalytics_job_test.go
@@ -318,6 +318,8 @@ func TestAccAzureRMStreamAnalyticsJob_transformation(t *testing.T) {
 	})
 }
 
+//TODO datalake output
+
 func testCheckAzureRMStreamAnalyticsJobDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*ArmClient).streamAnalyticsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
@@ -634,7 +636,6 @@ resource "azurerm_streamanalytics_job" "test" {
       storage_account_key  = "${azurerm_storage_account.test.primary_access_key}"
       storage_container    = "${azurerm_storage_container.test.name}"
       storage_path_pattern = "/test/{date}/{time}/test.json"
-      storage_date_format  = "yyyy-MM-dd"
       storage_time_format  = "HH"
   }
 }

--- a/azurerm/resource_arm_streamanalytics_job_test.go
+++ b/azurerm/resource_arm_streamanalytics_job_test.go
@@ -400,15 +400,15 @@ resource "azurerm_eventhub" "test" {
 }
 
 resource "azurerm_eventhub_authorization_rule" "test" {
-  name 	              = "acctesteventhubauth-%d"
+  name                = "acctesteventhubauth-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   namespace_name      = "${azurerm_eventhub_namespace.test.name}"
   eventhub_name       = "${azurerm_eventhub.test.name}"
-  listen 	      = true
+  listen              = true
 }
 
 resource "azurerm_eventhub_consumer_group" "test" {
-  name 		      = "acctesteventhubconsumer-%d"
+  name                = "acctesteventhubconsumer-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   namespace_name      = "${azurerm_eventhub_namespace.test.name}"
   eventhub_name       = "${azurerm_eventhub.test.name}"
@@ -418,16 +418,16 @@ resource "azurerm_streamanalytics_job" "test" {
   name                = "accteststreamanalyticsjob-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku   	      = "Standard"
+  sku                 = "Standard"
 
   input {
-    name 	  = "acctesteventhubinput-%d"
-    type 	  = "Stream"
+    name          = "acctesteventhubinput-%d"
+    type          = "Stream"
     serialization = "Avro"
-    datasource 	  = "Microsoft.ServiceBus/EventHub"
+    datasource    = "Microsoft.ServiceBus/EventHub"
 
     service_bus_namespace     = "${azurerm_eventhub_namespace.test.name}"
-    eventhub_name 	      = "${azurerm_eventhub.test.name}"
+    eventhub_name             = "${azurerm_eventhub.test.name}"
     shared_access_policy_name = "${azurerm_eventhub_authorization_rule.test.name}"
     shared_access_policy_key  = "${azurerm_eventhub_authorization_rule.test.primary_key}"
     consumer_group_name       = "${azurerm_eventhub_consumer_group.test.name}"
@@ -459,22 +459,22 @@ resource "azurerm_storage_container" "test" {
 }
 
 resource "azurerm_storage_blob" "test" {
-  name 			 = "acctestblob-%d"
+  name                   = "acctestblob-%d"
   resource_group_name    = "${azurerm_resource_group.test.name}"
   storage_account_name   = "${azurerm_storage_account.test.name}"
   storage_container_name = "${azurerm_storage_container.test.name}"
-  type 			 = "block"
+  type                   = "block"
 }
 
 resource "azurerm_streamanalytics_job" "test" {
   name                = "accteststreamanalyticsjob-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku   	      = "Standard"
+  sku                 = "Standard"
 
   input {
-    name 	  = "acctestblobinput-%d"
-    type 	  = "Reference"
+    name          = "acctestblobinput-%d"
+    type          = "Reference"
     serialization = "Json"
     encoding      = "UTF8"
     datasource    = "Microsoft.Storage/Blob"
@@ -502,27 +502,27 @@ resource "azurerm_sql_server" "test" {
   resource_group_name          = "${azurerm_resource_group.test.name}"
   location                     = "${azurerm_resource_group.test.location}"
   version                      = "12.0"
-  administrator_login	       = "mradministrator"
+  administrator_login          = "mradministrator"
   administrator_login_password = "thisIsDog11"
 }
 
 resource "azurerm_sql_database" "test" {
   name                = "acctestsqldb-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  location 	      = "${azurerm_resource_group.test.location}"
-  server_name 	      = "${azurerm_sql_server.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  server_name         = "${azurerm_sql_server.test.name}"
 }
 
 resource "azurerm_streamanalytics_job" "test" {
   name                = "accteststreamanalyticsjob-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku   	      = "Standard"
+  sku                 = "Standard"
 
   output {
-    name 	      = "acctestdboutput-%d"
+    name              = "acctestdboutput-%d"
     serialization     = "Avro"
-    datasource 	      = "Microsoft.Sql/Server/Database"
+    datasource        = "Microsoft.Sql/Server/Database"
     database_server   = "${azurerm_sql_server.test.name}"
     database_name     = "${azurerm_sql_database.test.name}"
     database_table    = "something"
@@ -557,15 +557,15 @@ resource "azurerm_eventhub" "test" {
 }
 
 resource "azurerm_eventhub_authorization_rule" "test" {
-  name 		      = "acctesteventhubauth-%d"
+  name                = "acctesteventhubauth-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   namespace_name      = "${azurerm_eventhub_namespace.test.name}"
   eventhub_name       = "${azurerm_eventhub.test.name}"
-  send 		      = true
+  send                = true
 }
 
 resource "azurerm_eventhub_consumer_group" "test" {
-  name 		      = "acctesteventhubconsumer-%d"
+  name                = "acctesteventhubconsumer-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   namespace_name      = "${azurerm_eventhub_namespace.test.name}"
   eventhub_name       = "${azurerm_eventhub.test.name}"
@@ -575,14 +575,14 @@ resource "azurerm_streamanalytics_job" "test" {
   name                = "accteststreamanalyticsjob-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku   	      = "Standard"
+  sku                 = "Standard"
 
   output {
-    name 		      = "acctesteventhuboutput-%d"
-    serialization 	      = "Avro"
-    datasource 		      = "Microsoft.ServiceBus/EventHub"
+    name                      = "acctesteventhuboutput-%d"
+    serialization             = "Avro"
+    datasource                = "Microsoft.ServiceBus/EventHub"
     service_bus_namespace     = "${azurerm_eventhub_namespace.test.name}"
-    eventhub_name 	      = "${azurerm_eventhub.test.name}"
+    eventhub_name             = "${azurerm_eventhub.test.name}"
     shared_access_policy_name = "${azurerm_eventhub_authorization_rule.test.name}"
     shared_access_policy_key  = "${azurerm_eventhub_authorization_rule.test.primary_key}"
   }
@@ -613,30 +613,30 @@ resource "azurerm_storage_container" "test" {
 }
 
 resource "azurerm_storage_blob" "test" {
-  name = "acctestblob-%d"
+  name                   = "acctestblob-%d"
   resource_group_name    = "${azurerm_resource_group.test.name}"
   storage_account_name   = "${azurerm_storage_account.test.name}"
   storage_container_name = "${azurerm_storage_container.test.name}"
-  type = "block"
+  type                   = "block"
 }
 
 resource "azurerm_streamanalytics_job" "test" {
   name                = "accteststreamanalyticsjob-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku   	      = "Standard"
+  sku                 = "Standard"
 
   output {
-    name 	  = "acctestbloboutput-%d"
+    name          = "acctestbloboutput-%d"
     serialization = "Json"
-    encoding 	  = "UTF8"
-    datasource 	  = "Microsoft.Storage/Blob"
+    encoding      = "UTF8"
+    datasource    = "Microsoft.Storage/Blob"
 
-    storage_account_name   = "${azurerm_storage_account.test.name}"
-      storage_account_key  = "${azurerm_storage_account.test.primary_access_key}"
-      storage_container    = "${azurerm_storage_container.test.name}"
-      storage_path_pattern = "/test/{date}/{time}/test.json"
-      storage_time_format  = "HH"
+    storage_account_name = "${azurerm_storage_account.test.name}"
+    storage_account_key  = "${azurerm_storage_account.test.primary_access_key}"
+    storage_container    = "${azurerm_storage_container.test.name}"
+    storage_path_pattern = "/test/{date}/{time}/test.json"
+    storage_time_format  = "HH"
   }
 }
 `, rInt, location, rInt, rInt, rInt, rInt, rInt)
@@ -667,16 +667,16 @@ resource "azurerm_eventhub" "test" {
 
 # Create authorization rule for listening on the event hub
 resource "azurerm_eventhub_authorization_rule" "test" {
-  name 		      = "acctesteventhubauth-%d"
+  name                = "acctesteventhubauth-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   namespace_name      = "${azurerm_eventhub_namespace.test.name}"
   eventhub_name       = "${azurerm_eventhub.test.name}"
-  listen 	      = true
+  listen              = true
 }
 
 # Create consumer group on the event hub
 resource "azurerm_eventhub_consumer_group" "test" {
-  name 		      = "acctesteventhubconsumer-%d"
+  name                = "acctesteventhubconsumer-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   namespace_name      = "${azurerm_eventhub_namespace.test.name}"
   eventhub_name       = "${azurerm_eventhub.test.name}"
@@ -687,7 +687,7 @@ resource "azurerm_sql_server" "test" {
   resource_group_name          = "${azurerm_resource_group.test.name}"
   location                     = "${azurerm_resource_group.test.location}"
   version                      = "12.0"
-  administrator_login 	     = "mradministrator"
+  administrator_login          = "mradministrator"
   administrator_login_password = "thisIsDog11"
 }
 
@@ -705,12 +705,12 @@ resource "azurerm_streamanalytics_job" "test" {
   sku                 = "Standard"
 
   input {
-    name 		      = "accteststreaminput-%d"
-    type 		      = "Stream"
-    serialization 	      = "Avro"
-    datasource 		      = "Microsoft.ServiceBus/EventHub"
+    name                      = "accteststreaminput-%d"
+    type                      = "Stream"
+    serialization             = "Avro"
+    datasource                = "Microsoft.ServiceBus/EventHub"
     service_bus_namespace     = "${azurerm_eventhub_namespace.test.name}"
-    eventhub_name 	      = "${azurerm_eventhub.test.name}"
+    eventhub_name             = "${azurerm_eventhub.test.name}"
     shared_access_policy_name = "${azurerm_eventhub_authorization_rule.test.name}"
     shared_access_policy_key  = "${azurerm_eventhub_authorization_rule.test.primary_key}"
     consumer_group_name       = "${azurerm_eventhub_consumer_group.test.name}"
@@ -722,9 +722,9 @@ resource "azurerm_streamanalytics_job" "test" {
   }
 
   output {
-    name 	      = "accteststreamoutput-%d"
+    name              = "accteststreamoutput-%d"
     serialization     = "Avro"
-    datasource 	      = "Microsoft.Sql/Server/Database"
+    datasource        = "Microsoft.Sql/Server/Database"
     database_server   = "${azurerm_sql_server.test.name}"
     database_name     = "${azurerm_sql_database.test.name}"
     database_table    = "something"


### PR DESCRIPTION
* Added acceptance tests for output sources (EventHub, Sql DB and Storage Blob) and transformations
* Added acceptance test for both stream and reference input sources
* Removed minimum requirements on input, transformation and outputs in the Schema
* Added validation and handling for both required and optional properties on output sources (**n.b** this is seperate to usual validation that is handled within the Schema definition. Atm, terraform doesn't support validation on lists so validation is done before `CreateOrUpdate` is called on the SDK)